### PR TITLE
Fix/enable client id and secret credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,9 @@ ENV/
 # Rope project settings
 .ropeproject
 
+#vscode
+.vscode
+
 # Mac
 ._*
 .DS_Store

--- a/tap_google_analytics/ga_client.py
+++ b/tap_google_analytics/ga_client.py
@@ -11,7 +11,7 @@ from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
 from oauth2client.service_account import ServiceAccountCredentials
-from oauth2client.client import GoogleCredentials, _raise_exception_for_missing_fields
+from oauth2client.client import GoogleCredentials
 from google.oauth2.credentials import Credentials
 
 from httplib2 import Http
@@ -181,7 +181,8 @@ class GAClient:
         elif self.auth_http == None:
             return build('analyticsreporting', 'v4', credentials=self.credentials) 
         else:
-            sys.exit("No valid way to use your credentials.")
+            LOGGER.critical("No valid way to use your credentials.")
+            sys.exit(1)
 
     def fetch_metadata(self):
         """
@@ -206,7 +207,8 @@ class GAClient:
         elif self.auth_http == None:
             service = build('analytics', 'v3', credentials=self.credentials, requestBuilder=self.requestBuilder)
         else:
-            sys.exit("No valid way to use your credentials.")
+            LOGGER.critical("No valid way to use your credentials.")
+            sys.exit(1)
 
         results = service.metadata().columns().list(reportType='ga', quotaUser=self.quota_user).execute()
 

--- a/tap_google_analytics/ga_client.py
+++ b/tap_google_analytics/ga_client.py
@@ -11,7 +11,7 @@ from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
 from oauth2client.service_account import ServiceAccountCredentials
-from oauth2client.client import GoogleCredentials
+from oauth2client.client import GoogleCredentials, _raise_exception_for_missing_fields
 from google.oauth2.credentials import Credentials
 
 from httplib2 import Http
@@ -79,7 +79,7 @@ class GAClient:
     def __init__(self, config):
         self.view_id = config['view_id']
         self.start_date = config['start_date']
-        self.end_date = config['end_date']
+        self.end_date = config.get('end_date', None)
         self.quota_user = config.get('quota_user', None)
 
         self.credentials = self.initialize_credentials(config)
@@ -93,11 +93,15 @@ class GAClient:
     def initialize_requestbuilder(self):
         return HttpRequest
 
+
     def initialize_http(self):
         return Http()
 
     def initialize_auth_http(self):
-        return AuthorizedHttp(http=self.http, credentials=self.credentials)
+        if type(self.credentials) == Credentials:
+            return AuthorizedHttp(http=self.http, credentials=self.credentials)
+        else:
+            return None
 
     def initialize_credentials(self, config):
         if config.get('authorization', {}).get('bearer_token', None):
@@ -105,7 +109,9 @@ class GAClient:
             return Credentials(token=config['authorization']['bearer_token'], refresh_handler=self.noop_refresh_handler)
         elif config.get('oauth_credentials', {}).get('refresh_proxy_url', None) \
                 and config.get('oauth_credentials', {}).get('access_token', None) \
-                and config.get('oauth_credentials', {}).get('refresh_token', None):
+                and config.get('oauth_credentials', {}).get('refresh_token', None) \
+                and config.get('oauth_credentials', {}).get('client_id') == None \
+                and config.get('oauth credentials', {}).get('client_secret') == None:
             # overriding the refresh request, via a token broker / proxy
             self.oauth_credentials = config['oauth_credentials']
             return Credentials(token=config['oauth_credentials']['access_token'], refresh_handler=self.proxy_refresh_handler)
@@ -167,23 +173,24 @@ class GAClient:
 
     def initialize_analyticsreporting(self):
         """Initializes an Analytics Reporting API V4 service object.
-
         Returns:
             An authorized Analytics Reporting API V4 service object.
         """
-        return build('analyticsreporting', 'v4', http=self.auth_http)
+        if self.auth_http != None:
+            return build('analyticsreporting', 'v4', http=self.auth_http)
+        elif self.auth_http == None:
+            return build('analyticsreporting', 'v4', credentials=self.credentials) 
+        else:
+            sys.exit("No valid way to use your credentials.")
 
     def fetch_metadata(self):
         """
         Fetch the valid (dimensions, metrics) for the Analytics Reporting API
          and their data types.
-
         Returns:
           A map of (dimensions, metrics) hashes
-
           Each available dimension can be found in dimensions with its data type
             as the value. e.g. dimensions['ga:userType'] == STRING
-
           Each available metric can be found in metrics with its data type
             as the value. e.g. metrics['ga:sessions'] == INTEGER
         """
@@ -194,7 +201,12 @@ class GAClient:
         # This is needed in order to dynamically fetch the metadata for available
         #   metrics and dimensions.
         # (those are not provided in the Analytics Reporting API V4)
-        service = build('analytics', 'v3', http=self.auth_http, requestBuilder=self.requestBuilder)
+        if self.auth_http != None:
+            service = build('analytics', 'v3', http=self.auth_http, requestBuilder=self.requestBuilder)
+        elif self.auth_http == None:
+            service = build('analytics', 'v3', credentials=self.credentials, requestBuilder=self.requestBuilder)
+        else:
+            sys.exit("No valid way to use your credentials.")
 
         results = service.metadata().columns().list(reportType='ga', quotaUser=self.quota_user).execute()
 
@@ -309,7 +321,6 @@ class GAClient:
                           giveup=is_fatal_error)
     def query_api(self, report_definition, pageToken=None):
         """Queries the Analytics Reporting API V4.
-
         Returns:
             The Analytics Reporting API V4 response.
         """
@@ -330,10 +341,8 @@ class GAClient:
 
     def process_response(self, response):
         """Processes the Analytics Reporting API V4 response.
-
         Args:
             response: An Analytics Reporting API V4 response.
-
         Returns: (nextPageToken, results)
             nextPageToken: The next Page Token
              If it is not None then the maximum pageSize has been reached

--- a/tap_google_analytics/tests/test_core.py
+++ b/tap_google_analytics/tests/test_core.py
@@ -22,16 +22,6 @@ class TestCore(unittest.TestCase):
         return self.requestBuilder
 
     def _mock_initialize_http(self):
-        mock_analyticsreporting_response = readfile(datafile('analyticsreporting-servicedocument.json'))
-        mock_analytics_response = readfile(datafile('analytics-servicedocument.json'))
-        self.mock_http = MockHttp(
-            [
-                # GET https://www.googleapis.com/discovery/v1/apis/analyticsreporting/v4/rest
-                MockResponse(data=mock_analyticsreporting_response),
-                # GET https://www.googleapis.com/discovery/v1/apis/analytics/v3/rest
-                MockResponse(data=mock_analytics_response)
-            ]
-        )
         return self.mock_http
 
     @patch('tap_google_analytics.ga_client.GAClient.initialize_http')
@@ -56,9 +46,73 @@ class TestCore(unittest.TestCase):
             }
         )
 
+        mock_analyticsreporting_response = readfile(datafile('analyticsreporting-servicedocument.json'))
+        mock_analytics_response = readfile(datafile('analytics-servicedocument.json'))
+        self.mock_http = MockHttp(
+            [
+                # GET https://www.googleapis.com/discovery/v1/apis/analyticsreporting/v4/rest
+                MockResponse(data=mock_analyticsreporting_response),
+                # GET https://www.googleapis.com/discovery/v1/apis/analytics/v3/rest
+                MockResponse(data=mock_analytics_response)
+            ]
+        )
+
         # when discover default catalog with 'authorization.bearer_token'
         catalog = tap_google_analytics.discover(mock_config)
 
         # expect valid catalog to be discovered
         self.assertEqual(len(catalog['streams']), 10, "Total streams from default catalog")
 
+
+    @patch('tap_google_analytics.ga_client.GAClient.initialize_http')
+    @patch('tap_google_analytics.ga_client.GAClient.initialize_requestbuilder')
+    def test_client_id_and_client_secret_with_refresh_proxy_url_discover(self,stub_initialize_requestbuilder , stub_initialize_http):
+        """ Test basic discover sync with client_id and client_secret"""
+        # given all required config
+        mock_config = {
+            'view_id': '123456789',
+            'start_date': datetime.datetime.now().strftime("%Y-%m-%d"),
+            'oauth_credentials': {
+                'refresh_proxy_url': 'mock-url',
+                'access_token': 'mock-token',
+                'refresh_token': 'mock-refresh-token',
+                'client_id': '123456789',
+                'client_secret' : '123456789'
+            },
+        }
+
+        # given mock service documents
+        mock_analyticsreporting_response = readfile(datafile('analyticsreporting-servicedocument.json'))
+        mock_analytics_response = readfile(datafile('analytics-servicedocument.json'))
+        # given mock metadata successful response
+        stub_initialize_requestbuilder.side_effect = self._mock_initialize_requestbuilder
+        mock_metadata_response = readfile(datafile('analytics-metadata-columns-list.json'))
+        self.requestBuilder = RequestMockBuilder(
+            {"analytics.metadata.columns.list": 
+                (None, mock_metadata_response)
+            }
+        )
+        # given mock service documents
+        mock_analyticsreporting_response = readfile(datafile('analyticsreporting-servicedocument.json'))
+        mock_analytics_response = readfile(datafile('analytics-servicedocument.json'))
+        # given mock successful metadata response        
+        mock_metadata_response = readfile(datafile('analytics-metadata-columns-list.json'))
+        # given mock http responses
+        mock_http_metadata = MockHttp(
+            [
+                # GET https://www.googleapis.com/discovery/v1/apis/analyticsreporting/v4/rest
+                MockResponse(data=mock_analyticsreporting_response),
+                # GET https://www.googleapis.com/discovery/v1/apis/analytics/v3/rest
+                MockResponse(data=mock_analytics_response),
+                # GET https://analytics.googleapis.com/analytics/v3/metadata/ga/columns?alt=json
+                MockResponse(data=mock_metadata_response)
+            ]
+        )
+        self.mock_http = mock_http_metadata
+        stub_initialize_http.side_effect = self._mock_initialize_http
+
+        # when discover default catalog with 'oauth_credentials.refresh_proxy_url'
+        catalog = tap_google_analytics.discover(mock_config)
+
+        # expect valid catalog to be discovered
+        self.assertEqual(len(catalog['streams']), 10, "Total streams from default catalog")


### PR DESCRIPTION
- Added conditional logic around initializing authhttp, as you can only do it using oauth credentials.
- Added conditional logic around creating service build() as again oauth credentials and client_id and client_secret differ.
- Updated conditional logic around selecting which credentials to use.
- Added test "test_client_id_and_client_secret_with_refresh_proxy_url_discover" to make sure the updated logic around selecting credentials work.
- Updated test_core to set up self.mock_http for each test within the test.
- Updated gitignore to ignore .vscode files.